### PR TITLE
Add David Gilliland audio posts

### DIFF
--- a/_posts/audio/Speakers/2026-05-25-David-Gilliland.md
+++ b/_posts/audio/Speakers/2026-05-25-David-Gilliland.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: "David Gilliland Messages"
+date: 2026-05-25
+category: audio
+---
+
+<ul>
+  {% assign conf_posts = site.categories.davidgilliland | sort: "date" | reverse %}
+  {% for post in conf_posts %}
+    <li>
+      <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+    </li>
+  {% endfor %}
+</ul>

--- a/_posts/audio/Speakers/David-Gilliland/2026-05-25-David-Gilliland-The-Plains-of-Moab.md
+++ b/_posts/audio/Speakers/David-Gilliland/2026-05-25-David-Gilliland-The-Plains-of-Moab.md
@@ -1,0 +1,82 @@
+---
+layout: post
+title: "2026-05-25 - David Gilliland - The Plains of Moab"
+slug: 2026-05-25-David-Gilliland-The-Plains-of-Moab
+date: 2026-05-25
+category: [davidgilliland]
+---
+
+These Audio files were uploaded to Archive.org as part of the David Gilliland collection <br>
+
+
+<p>
+🎵 01 - David Gilliland - The Plains of Moab 01 <br>
+<audio controls>
+  <source src="https://archive.org/download/david-gilliland_202605/David%20Gilliland%20-%20The%20Plains%20of%20Moab/gilliland-david-the-plains-of-moab-01.mp3" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>
+</p>
+
+<p>
+🎵 02 - David Gilliland - The Plains of Moab 02 <br>
+<audio controls>
+  <source src="https://archive.org/download/david-gilliland_202605/David%20Gilliland%20-%20The%20Plains%20of%20Moab/gilliland-david-the-plains-of-moab-02.mp3" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>
+</p>
+
+<p>
+🎵 03 - David Gilliland - The Plains of Moab 03 <br>
+<audio controls>
+  <source src="https://archive.org/download/david-gilliland_202605/David%20Gilliland%20-%20The%20Plains%20of%20Moab/gilliland-david-the-plains-of-moab-03.mp3" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>
+</p>
+
+<p>
+🎵 04 - David Gilliland - The Plains of Moab 04 <br>
+<audio controls>
+  <source src="https://archive.org/download/david-gilliland_202605/David%20Gilliland%20-%20The%20Plains%20of%20Moab/gilliland-david-the-plains-of-moab-04.mp3" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>
+</p>
+
+<p>
+🎵 05 - David Gilliland - The Plains of Moab 05 <br>
+<audio controls>
+  <source src="https://archive.org/download/david-gilliland_202605/David%20Gilliland%20-%20The%20Plains%20of%20Moab/gilliland-david-the-plains-of-moab-05.mp3" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>
+</p>
+
+<p>
+🎵 06 - David Gilliland - The Plains of Moab 06 <br>
+<audio controls>
+  <source src="https://archive.org/download/david-gilliland_202605/David%20Gilliland%20-%20The%20Plains%20of%20Moab/gilliland-david-the-plains-of-moab-06.mp3" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>
+</p>
+
+<p>
+🎵 07 - David Gilliland - The Plains of Moab 07 <br>
+<audio controls>
+  <source src="https://archive.org/download/david-gilliland_202605/David%20Gilliland%20-%20The%20Plains%20of%20Moab/gilliland-david-the-plains-of-moab-07.mp3" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>
+</p>
+
+<p>
+🎵 08 - David Gilliland - The Plains of Moab 08 <br>
+<audio controls>
+  <source src="https://archive.org/download/david-gilliland_202605/David%20Gilliland%20-%20The%20Plains%20of%20Moab/gilliland-david-the-plains-of-moab-08.mp3" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>
+</p>
+
+<p>
+🎵 09 - David Gilliland - The Plains of Moab 09 <br>
+<audio controls>
+  <source src="https://archive.org/download/david-gilliland_202605/David%20Gilliland%20-%20The%20Plains%20of%20Moab/gilliland-david-the-plains-of-moab-09.mp3" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>
+</p>


### PR DESCRIPTION
Add speaker index and audio post for David Gilliland. Creates _posts/audio/Speakers/2026-05-25-David-Gilliland.md (speaker listing that enumerates posts in the 'davidgilliland' category) and _posts/audio/Speakers/David-Gilliland/2026-05-25-David-Gilliland-The-Plains-of-Moab.md (post embedding nine MP3 audio tracks hosted on Archive.org).
